### PR TITLE
Fixed callback scope.

### DIFF
--- a/raphael.set.hoverset.js
+++ b/raphael.set.hoverset.js
@@ -30,7 +30,7 @@ Raphael.st.hoverset = function(r, overfunc, outfunc, outdelay) {
 		r.getById(evt.target.raphaelid).data("Raphael.st.hoverset.over", true);
 
 		if(!home['Raphael.st.hoverset.overset']){
-			overfunc(evt);
+			overfunc.call(this, evt);
 		}
 
 		home['Raphael.st.hoverset.overset'] = true;
@@ -45,7 +45,7 @@ Raphael.st.hoverset = function(r, overfunc, outfunc, outdelay) {
 			overset = lookForOver(home);
 			if(!overset){
 				home['Raphael.st.hoverset.overset'] = false;
-				outfunc(evt)
+				outfunc.call(this, evt);
 			}
 		}, outdelay || 0);
 	}


### PR DESCRIPTION
I fixed the overfunc and outfunc scope. This made the callback scope consistent with what you'd see using `set.mouseover()`.
